### PR TITLE
Update Vanguard API and requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ Your `WEBULL_USERNAME` can be your email or phone number. If using a phone numbe
 To get your Webull DID, follow this [guide](https://github.com/tedchou12/webull/wiki/Workaround-for-Login-%E2%80%90-Method-2).
 
 ### Vanguard
-Made by [MaxxRK](https://github.com/MaxxRK/) using the [vanguard-api](https://github.com/MaxxRK/vanguard-api). Go give them a ⭐
+Made by [MaxxRK](https://github.com/MaxxRK/) using the [vanguard-api](https://github.com/MaxxRK/vanguard-api) (>=0.3.1). Go give them a ⭐
 
 Required `.env` variables:
 - `VANGUARD_USERNAME`

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,12 +14,12 @@ nodriver==0.45.2
 public-invest-api==1.3.3
 pyotp==2.9.0
 python-dotenv==1.1.0
-requests==2.32.3
+requests==2.32.4
 robin-stocks==3.4.0
 # schwab-api==0.4.3
 -e git+https://github.com/yanowitz/schwab-api.git@367ef565c35bf5c96b6d456c46c18ce05603d87a#egg=schwab-api
 selenium-stealth==1.0.6
 setuptools==80.3.1
 tastytrade==9.11
-vanguard-api==0.3.0
+vanguard-api==0.3.1
 -e git+https://github.com/NelsonDane/webull.git@ef14ae63f9e1436fbea77fe864df54847cf2f730#egg=webull


### PR DESCRIPTION
## Summary
- bump `requests` to 2.32.4
- bump `vanguard-api` to 0.3.1 and note version in README

## Testing
- `pytest -q` *(fails: BrowserType.launch_persistent_context: Chromium distribution 'chrome' is not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860227b32bc83299db03796fc728b3b